### PR TITLE
Fix: Create Output Directories if Don't Exist

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -100,7 +100,7 @@ if [ ! -z $INPUT_OUTPUT ]; then
 	out_dir="$dir/$INPUT_OUTPUT"
 fi
 
-if [ -n "$out_dir" ]; then
+if [ ! -z $out_dir ]; then
 	# create output directories if they don't exist
 	mkdir -p $out_dir
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ output_name () {
 	# but if it is just a `js/`, we need its full path
 	# not just the dirname, but also the basename with it
 	if [ -d "${in_dir}" ]; then
-		in_path=$( readlink $in_dir )
+		in_path=$f_dir
 	fi
 
 	f_path=$f_dir

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,8 @@ output_name () {
 	f_path=$f_dir
 	if [ ! -z $out_dir ]; then
 		f_path="$out_dir/${f_dir#"$in_path"}"
+
+		mkdir -p $f_path
 	fi
 
 	echo "$f_path/$f_name.min$f_extn" | xargs readlink -m


### PR DESCRIPTION
This pull request resolves the issue #8. This testing branch for this issue can be found on [auto-minify-test/issues#8](https://github.com/nizarmah/auto-minify-test/tree/issues%238).

The successful GitHub Action can be found [here](https://github.com/nizarmah/auto-minify-test/runs/848724040).

Now, when the `output` directory is specified, it is created if it doesn't exist.
In addition, if the `directory` is nested (eg. `js/*`), all the sub-directories in the `js` directory are then created in the output directory.

For example, consider the following
```
directory: 'js/*'
output: 'production/js'

if $output doesn't exist:
    create $output directory

go through directory:
    for example, we reach '$directory/something'
    if '$output/something' doesn't exist:
        create '$output/something' directory
```