### PR TITLE
Feature: Added Maxdepth Input Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Minifies JS and CSS files with Babel-Minify and CleanCSS
 | -- | -- | -- | -- |
 | directory | Directory that contains the files you want to minify. | false | . ( current directory ) |
 | output | Directory that contains the minified files. | false | same as directory |
+| maxdepth | Descend at most levels (a non-negative integer) levels of directories below the starting-points. | false | "" (empty) |
+
+> With the addition of `maxdepth`, the action traverses by default into all subdirectories in a specified directory.
+>
+> ##### [Follow this example if you want to minify the files in the first level of a certain directory.](#specifying-maxdepth)
 
 ### Example
 
@@ -20,6 +25,27 @@ steps:
 
   - name: Auto Minify
     uses: nizarmah/auto-minify@master
+
+  # Auto commits minified files to the repository
+  # Ignore it if you don't want to commit the files to the repository 
+  - name: Auto committing minified files
+    uses: stefanzweifel/git-auto-commit-action@v3.0.0
+    with:
+      commit_message: "Github Action: Auto Minified JS and CSS files"
+      branch: ${{ github.ref }}
+```
+
+##### Specifying Maxdepth
+
+```
+steps:
+  # Checks-out your repository under $GITHUB_WORKSPACE, so auto-minify job can access it
+  - uses: actions/checkout@v2
+
+  - name: Auto Minify
+    uses: nizarmah/auto-minify@master
+    with:
+      maxdepth: 1
 
   # Auto commits minified files to the repository
   # Ignore it if you don't want to commit the files to the repository 

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: "Directory that contains the minified files. Defaults to same directory"
     required: false
     default: ""
+  maxdepth:
+    description: "Descend at most levels (a non-negative integer) levels of directories below the starting-points."
+    required: false
+    default: ""
 
 runs:
   using: "docker"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,13 +44,26 @@ find_files () {
 		1- js | css (supported file extension)
 
 	find all files of certain type inside in_dir
-		- `-maxdepth` helps us specify only specified scope
 		- `find` returns the relative path, which is needed
 		- `*` acts as a recursive operator
 
 	Piped into grep to get all non minified files
+
+	optional parameters:
+		- `-maxdepth`
+
+	Clear all optional parameter keys in case the values are empty
+	So, when appended to the command parameters, no error is caused
 	'
-	find $in_dir -maxdepth 1 -type f -name "*.$1" | grep -v ".min.$1$"
+
+	MAXDEPTH_KEY="-maxdepth"
+	MAXDEPTH_VAL=$INPUT_MAXDEPTH
+
+	if [ -z $MAXDEPTH_VAL ]; then
+		MAXDEPTH_KEY=""
+	fi
+
+	find $in_dir ${MAXDEPTH_KEY} ${MAXDEPTH_VAL} -type f -name "*.$1" | grep -v ".min.$1$"
 }
 
 exec_minify_cmd () {


### PR DESCRIPTION
This specifies the `maxdepth` for the `find` command that searches for the `js` and `css` files. 

By default, the `maxdepth` is set to `""`, which leads to continuously searching through nested directories.