### PR TITLE
Feature: Adds JS_ENGINE Input to decide which Package Minifies the JS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Minifies JS and CSS files with Babel-Minify and CleanCSS
 | directory | Directory that contains the files you want to minify. | false | . ( current directory ) |
 | output | Directory that contains the minified files. | false | same as directory |
 | maxdepth | Descend at most levels (a non-negative integer) levels of directories below the starting-points. | false | "" (empty) |
+| js_engine | Specifies which of the supported packages minifies JS files. Supported packages: `babel`, `uglify-js` | false | babel |
 
 > With the addition of `maxdepth`, the action traverses by default into all subdirectories in a specified directory.
 >

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: "Descend at most levels (a non-negative integer) levels of directories below the starting-points."
     required: false
     default: ""
+  js_engine:
+    description: "Specifies which of the supported packages minifies JS files."
+    required: false
+    default: "babel"
 
 runs:
   using: "docker"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,6 +66,28 @@ find_files () {
 	find $in_dir ${MAXDEPTH_KEY} ${MAXDEPTH_VAL} -type f -name "*.$1" | grep -v ".min.$1$"
 }
 
+exec_minify_js () {
+	: '
+	arguments:
+		1- input file
+		2- output file
+
+	returns the command needed to minify the js file
+	based on the requested JavaScript Engine in the
+	input `js_engine` 
+	'
+	file=$1
+	out=$2
+
+	js_engine=$INPUT_JS_ENGINE
+
+	if [[ $js_engine == "babel" ]]; then
+		npx minify $file --out-file $out
+	elif [[ $js_engine == "uglify-js" ]]; then
+		npx uglifyjs $file --compress --mangle --output $out
+	fi
+}
+
 exec_minify_cmd () {
 	: '
 	arguments: 
@@ -79,7 +101,7 @@ exec_minify_cmd () {
 	out=$2
 
 	if [[ $file == *.js ]]; then
-		npx minify $file --out-file $out
+		exec_minify_js $file $out
 	elif [[ $file == *.css ]]; then
 		npx cleancss -o $out $file
 	fi

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"repository": "nizarmah/auto-minify",
 	"homepage": "https://github.com/nizarmah/auto-minify/",
 	"dependencies": {
+		"uglify-js": "^3.10.0",
 		"babel-minify": "^0.5.1",
 		"clean-css-cli": "^4.3.0"
 	},


### PR DESCRIPTION
Adds support for different JS minification engines. Currently support engines:
- [x] Babel Minify
- [x] Uglify-JS 

Supported JS_ENGINE values:
- `babel`
- `uglify-js`

Tested on [Auto-Minify-Test/feature/js_engine](https://github.com/nizarmah/auto-minify-test/tree/feature/js_engine).

![image](https://user-images.githubusercontent.com/5631091/88579543-da80ef00-d052-11ea-8cfc-26626c38f3dc.png)

[Click here to see build results](https://github.com/nizarmah/auto-minify-test/runs/915934792)