### PR TITLE
Fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ steps:
       branch: ${{ github.ref }}
 ```
 
-##### Specifying output directory
+##### Specifying input directory
 
 ```
 steps:


### PR DESCRIPTION
I guess input directoy is meant in this case instead.