### PR TITLE
Switch to alpine linux 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM node:13.10
+FROM node:current-alpine3.12
 
 WORKDIR /app/
 
 COPY package.json /app/package.json
 
-RUN npm install
-
-RUN npm list
+RUN apk add --no-cache bash coreutils \
+ && apk add --no-cache --upgrade grep \
+ && npm install
 
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Switches from debian to alpine linux, lowering build time to about 20 seconds.
Also removes the npm list because it just adds unnecessary time to the build.