### PR TITLE
Fixes issue with file names ending in "min" from being skipped

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,7 @@ find_files () {
 		MAXDEPTH_KEY=""
 	fi
 
-	find $in_dir ${MAXDEPTH_KEY} ${MAXDEPTH_VAL} -type f -name "*.$1" | grep -v ".min.$1$"
+	find $in_dir ${MAXDEPTH_KEY} ${MAXDEPTH_VAL} -type f -name "*.$1" -not \( -iname "*\.min.$1" \)
 }
 
 exec_minify_js () {


### PR DESCRIPTION
In the current version, if we use a file named `admin.css` or `admin.js` it will be skipped for the minification because the `admin` name ends with `min`. This PR addresses a fix for this situation allowing filenames ending with `min` to be included as well.