### PR TITLE
Revert include mjs in minified files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -154,7 +154,6 @@ fi
 
 file_set=$({
 	find_files 'js' &
-	find_files 'mjs' &
 	find_files 'css' &
 })
 


### PR DESCRIPTION
mjs files are not supported by babel-minify. I overlooked the minified file when testing due to a small rush I was in. The previous pull request (#21) shouldn't have been merged.