### PR TITLE
Update action version number in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ steps:
   - uses: actions/checkout@v2
 
   - name: Auto Minify
-    uses: nizarmah/auto-minify@v2
+    uses: nizarmah/auto-minify@v2.1
 
   # Auto commits minified files to the repository
   # Ignore it if you don't want to commit the files to the repository 
@@ -45,7 +45,7 @@ steps:
   - uses: actions/checkout@v2
 
   - name: Auto Minify
-    uses: nizarmah/auto-minify@v2
+    uses: nizarmah/auto-minify@v2.1
     with:
       overwrite: true
 
@@ -66,7 +66,7 @@ steps:
   - uses: actions/checkout@v2
 
   - name: Auto Minify
-    uses: nizarmah/auto-minify@v2
+    uses: nizarmah/auto-minify@v2.1
     with:
       maxdepth: 1
 
@@ -87,7 +87,7 @@ steps:
   - uses: actions/checkout@v2
 
   - name: Auto Minify
-    uses: nizarmah/auto-minify@v2
+    uses: nizarmah/auto-minify@v2.1
     with:
       directory: 'js'
 
@@ -111,7 +111,7 @@ steps:
   - uses: actions/checkout@v2
 
   - name: Auto Minify
-    uses: nizarmah/auto-minify@v2
+    uses: nizarmah/auto-minify@v2.1
     with:
       directory: 'js'
       output: 'mini_js'


### PR DESCRIPTION
On attempting to use this action it failed with the error `Unable to resolve action nizarmah/auto-minify@v2, unable to find version v2` - after checking the repository it looks like the examples have not been updated to match the release number.