### PR TITLE
Adds exclude_directories input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,12 @@ inputs:
     description: "Directory that contains the files you want to minify. Defaults to current directory (.)"
     required: false
     default: "."
+  exclude_directories:
+    description: "Exclude child folders from the main directory. Combine them in a string separated by semicolon and relative to the main directory eg. 'dir1;js/dir2;js/test/dir3'"
+    required: false
+    default: ""
   output:
-    description: "Directory that contains the minified files. Defaults to same directory"
+    description: "Directory that contains the minified files. Defaults to same directory."
     required: false
     default: ""
   overwrite:


### PR DESCRIPTION
Currently there is not way to exclude specific directories from minification. This PR addresses this issue by adding a new input called `exclude_directories` which is relative to the `directory` input. If using more than 1 directory, they should be separated by semicolon.

#### Example using 1 directory

```yml
- name: Auto Minify
        uses: alexmigf/auto-minify@exclude-dirs
        with:
          directory: 'assets'
          exclude_directories: 'js/pdf_js'
```

#### Example using 2 directories

```yml
- name: Auto Minify
        uses: alexmigf/auto-minify@exclude-dirs
        with:
          directory: 'assets'
          exclude_directories: 'js/pdf_js;js/test'
```