### PR TITLE
Add Lightning CSS minifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Minifies JS and CSS files with Babel-Minify and CleanCSS
 | overwrite | Overwrites the existing files with the minified version. Defaults to false. | false | false |
 | maxdepth | Descend at most levels (a non-negative integer) levels of directories below the starting-points. | false | "" (empty) |
 | js_engine | Specifies which of the supported packages minifies JS files. Supported packages: `babel`, `uglify-js` | false | babel |
+| css_engine | Specifies which of the supported packages minifies CSS files. Supported packages: `lightning`, `clean-css` | false | lightning |
 
 > With the addition of `maxdepth`, the action traverses by default into all subdirectories in a specified directory.
 >

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: "Specifies which of the supported packages minifies JS files."
     required: false
     default: "babel"
+  css_engine:
+    description: "Specifies which of the supported packages minifies CSS files."
+    required: false
+    default: "lightning"
 
 runs:
   using: "docker"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -93,6 +93,28 @@ exec_minify_js () {
 	fi
 }
 
+exec_minify_css () {
+	: '
+	arguments:
+		1- input file
+		2- output file
+
+	returns the command needed to minify the css file
+	based on the requested CSS Engine in the
+	input `css_engine` 
+	'
+	file=$1
+	out=$2
+
+	css_engine=$INPUT_CSS_ENGINE
+
+	if [[ $css_engine == "clean-css" ]]; then
+		npx cleancss -o $out $file
+	elif [[ $css_engine == "lightning" ]]; then
+		npx lightningcss --minify $file --output-file $out
+	fi
+}
+
 exec_minify_cmd () {
 	: '
 	arguments: 
@@ -108,7 +130,7 @@ exec_minify_cmd () {
 	if [[ $file == *.js ]]; then
 		exec_minify_js $file $out
 	elif [[ $file == *.css ]]; then
-		npx cleancss -o $out $file
+		exec_minify_css $file $out
 	fi
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"dependencies": {
 		"uglify-js": "^3.10.0",
 		"babel-minify": "^0.5.1",
-		"clean-css-cli": "^4.3.0"
+		"clean-css-cli": "^4.3.0",
+		"lightningcss": "^1.24.1"
 	},
 	"author": {
 		"name": "Nizar Mahmoud",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"uglify-js": "^3.10.0",
 		"babel-minify": "^0.5.1",
 		"clean-css-cli": "^4.3.0",
-		"lightningcss": "^1.24.1"
+		"lightningcss-cli": "^1.24.1"
 	},
 	"author": {
 		"name": "Nizar Mahmoud",


### PR DESCRIPTION
This PR adds the [LightningCSS](https://lightningcss.dev/) engine to minify CSS. Clean-css is still available and selection between CSS minifiers is done just like between JS minifiers. Unlike clean-css, LightningCSS supports minification of CSS files using the new [nested selectors syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_nesting).